### PR TITLE
Fix documentation remote config pod name

### DIFF
--- a/docs/remote-config/ios.md
+++ b/docs/remote-config/ios.md
@@ -15,7 +15,7 @@ Add the `RNFBConfig` Pod to your projects `/ios/Podfile`:
 ```ruby{3}
 target 'app' do
   ...
-  pod 'RNFBConfig', :path => '../node_modules/@react-native-firebase/remote-config/ios'
+  pod 'RNFBRemoteConfig', :path => '../node_modules/@react-native-firebase/remote-config'
 end
 ```
 


### PR DESCRIPTION
Fixes the line to configure Remote Config module on iOS Podfile

